### PR TITLE
Hot fix/tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ DocxToJats is a PHP library that converts DOCX archives that comply OOXML standa
 
 DocxToJats is used as a submodule to the DOCX Converter Plugin, written for Open Journal Systems. Unfortunately DOCX archive doesn't contain much metadata and JATS `front` elements remain not populated, thus, the best way would be to integrate docxToJats with editorial manager from where article's metadata can be retrieved. DOCX Converter Plugin is such an example.    
 
-## Contribuciones
+## Contributions
 
-Este proyecto recibió contribuciones de:
+This project has received contributions from:
 
-- **PREBI-SEDICI**, Programa de Bibliotecas y Repositorios Institucionales, **Universidad Nacional de La Plata**  
-  Sitio web: [https://prebi-sedici.unlp.edu.ar/](https://prebi-sedici.unlp.edu.ar/)
+- **PREBI-SEDICI**, Program of Libraries and Institutional Repositories, **National University of La Plata**  
+  Website: [https://prebi-sedici.unlp.edu.ar/](https://prebi-sedici.unlp.edu.ar/)

--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ DocxToJats is a PHP library that converts DOCX archives that comply OOXML standa
 * How to achieve the best results: https://github.com/Vitaliy-1/docxConverter#how-to-achieve-best-results 
 
 DocxToJats is used as a submodule to the DOCX Converter Plugin, written for Open Journal Systems. Unfortunately DOCX archive doesn't contain much metadata and JATS `front` elements remain not populated, thus, the best way would be to integrate docxToJats with editorial manager from where article's metadata can be retrieved. DOCX Converter Plugin is such an example.    
+
+## Contribuciones
+
+Este proyecto recibió contribuciones de:
+
+- **PREBI-SEDICI**, Programa de Bibliotecas y Repositorios Institucionales, **Universidad Nacional de La Plata**  
+  Sitio web: [https://prebi-sedici.unlp.edu.ar/](https://prebi-sedici.unlp.edu.ar/)

--- a/src/docx2jats/jats/Cell.php
+++ b/src/docx2jats/jats/Cell.php
@@ -13,8 +13,14 @@ use docx2jats\objectModel\DataObject;
 use docx2jats\jats\Par as JatsPar;
 
 class Cell extends Element {
-	public function __construct(DataObject $dataObject) {
-		parent::__construct($dataObject);
+	
+	private $isHeaderCell = false;
+	
+	public function __construct(DataObject $dataObject, bool $isHeaderRow = false) {
+		$this->isHeaderCell = $isHeaderRow;
+		// Use 'th' for header cells, 'td' for regular cells
+		$elementName = $isHeaderRow ? 'th' : 'td';
+		parent::__construct($dataObject, $elementName);
 	}
 
 	public function setContent() {
@@ -35,5 +41,12 @@ class Cell extends Element {
 			$this->appendChild($par);
 			$par->setContent();
 		}
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isHeaderCell(): bool {
+		return $this->isHeaderCell;
 	}
 }

--- a/src/docx2jats/jats/Element.php
+++ b/src/docx2jats/jats/Element.php
@@ -16,11 +16,29 @@ abstract class Element extends \DOMElement {
 
 	private $dataObject;
 
-	public function __construct(DataObject $dataObject) {
+	public function __construct(DataObject $dataObject, string $elementNameOverride = '') {
 
 		$this->dataObject = $dataObject;
 
-		// Determing element name
+		// Determine element name (can be overridden by subclasses)
+		$name = !empty($elementNameOverride) ? $elementNameOverride : $this->determineElementName($dataObject);
+
+		/*
+		$textString = '';
+		foreach ($dataObject->getContent() as $text) {
+			$textString .= $text->getContent();
+		}
+		*/
+
+		if (!empty($name)) parent::__construct($name);
+	}
+
+	/**
+	 * Determine the JATS element name based on the data object class
+	 * @param DataObject $dataObject
+	 * @return string
+	 */
+	protected function determineElementName(DataObject $dataObject): string {
 		$name = '';
 		switch (get_class($dataObject)) {
 			case "docx2jats\objectModel\body\Par":
@@ -46,15 +64,7 @@ abstract class Element extends \DOMElement {
 			case "docx2jats\objectModel\body\Image":
 				$name = 'fig';
 		}
-
-		/*
-		$textString = '';
-		foreach ($dataObject->getContent() as $text) {
-			$textString .= $text->getContent();
-		}
-		*/
-
-		if (!empty($name)) parent::__construct($name);
+		return $name;
 	}
 
 	protected function getDataObject() {

--- a/src/docx2jats/jats/LinkTypeHelper.php
+++ b/src/docx2jats/jats/LinkTypeHelper.php
@@ -1,0 +1,75 @@
+<?php namespace docx2jats\jats;
+
+/**
+ * @file src/docx2jats/jats/LinkTypeHelper.php
+ *
+ * Copyright (c) 2025 Vitalii Bezsheiko
+ * Distributed under the GNU GPL v3.
+ *
+ * @brief Helper to infer ext-link-type from URL
+ */
+
+class LinkTypeHelper {
+
+	/**
+	 * Infers the ext-link-type based on the URL.
+	 * Returns null if no specific type is detected and it's not a standard URI/FTP.
+	 *
+	 * @param string $url
+	 * @return string|null
+	 */
+	public static function inferType(string $url): ?string {
+		$url = trim($url);
+		
+		if (empty($url)) {
+			return null;
+		}
+
+		// Check for specific protocols
+		if (strpos($url, 'ftp://') === 0) {
+			return 'ftp';
+		}
+
+
+		// Check for DOI
+		if (preg_match('/^10\.\d{4,9}\/[-._;()\/:A-Z0-9]+$/i', $url) || strpos($url, 'doi.org') !== false) {
+			return 'doi';
+		}
+
+		// Check for specific domains or patterns
+		if (strpos($url, 'chem.qmw.ac.uk/iubmb/enzyme') !== false) {
+			return 'ec';
+		}
+		if (strpos($url, 'ncbi.nlm.nih.gov/genbank') !== false) {
+			return 'gen';
+		}
+		if (strpos($url, 'ncbi.nlm.nih.gov/protein') !== false) {
+			return 'genpept';
+		}
+		if (strpos($url, 'pdb.org') !== false || strpos($url, 'rcsb.org') !== false) {
+			return 'pdb';
+		}
+		if (strpos($url, 'ebi.ac.uk/~textman/pgr-htdocs') !== false) {
+			return 'pgr';
+		}
+		if (strpos($url, 'pir.georgetown.edu') !== false) {
+			return 'pir';
+		}
+		if (strpos($url, 'ncbi.nlm.nih.gov/pmc') !== false) {
+			return 'pmcid';
+		}
+		if (strpos($url, 'ncbi.nlm.nih.gov/pubmed') !== false) {
+			return 'pmid';
+		}
+		if (strpos($url, 'uniprot.org') !== false || strpos($url, 'ebi.ac.uk/swissprot') !== false) {
+			return 'sprot';
+		}
+
+		// Default to uri only if it looks like a web URL
+		if (strpos($url, 'http://') === 0 || strpos($url, 'https://') === 0) {
+			return 'uri';
+		}
+
+		return 'uri';
+	}
+}

--- a/src/docx2jats/jats/Reference.php
+++ b/src/docx2jats/jats/Reference.php
@@ -155,7 +155,12 @@ class Reference extends \DOMElement {
 
 		$url = $this->getStdClassPropertyValue($data, 'URL');
 		if ($url) {
-			$urlEl = $this->createAndAppendElement($elementCitationEl, 'ext-link', $url);
+			$attrs = [];
+			$extLinkType = LinkTypeHelper::inferType($url);
+			if ($extLinkType) {
+				$attrs['ext-link-type'] = $extLinkType;
+			}
+			$urlEl = $this->createAndAppendElement($elementCitationEl, 'ext-link', $url, $attrs);
 		}
 
 		$issn = $this->getStdClassPropertyValue($data, 'ISSN');

--- a/src/docx2jats/jats/Row.php
+++ b/src/docx2jats/jats/Row.php
@@ -18,8 +18,11 @@ class Row extends Element {
 	}
 
 	public function setContent() {
-		foreach ($this->getDataObject()->getContent() as $content) {
-			$cell = new JatsCell($content);
+		$dataObject = $this->getDataObject(); /* @var $dataObject \docx2jats\objectModel\body\Row */
+		$isHeaderRow = $dataObject->isHeader();
+		
+		foreach ($dataObject->getContent() as $content) {
+			$cell = new JatsCell($content, $isHeaderRow);
 			$this->appendChild($cell);
 			$cell->setContent();
 		}

--- a/src/docx2jats/jats/Table.php
+++ b/src/docx2jats/jats/Table.php
@@ -61,9 +61,40 @@ class Table extends Element {
 		$tableNode = $this->ownerDocument->createElement('table');
 		$this->appendChild($tableNode);
 
+		// Separate header rows from body rows
+		$headerRows = array();
+		$bodyRows = array();
+		
 		foreach ($dataObject->getContent() as $content) {
+			/* @var $content \docx2jats\objectModel\body\Row */
+			if ($content->isHeader()) {
+				$headerRows[] = $content;
+			} else {
+				$bodyRows[] = $content;
+			}
+		}
+
+		// Create thead if there are header rows
+		if (!empty($headerRows)) {
+			$theadNode = $this->ownerDocument->createElement('thead');
+			$tableNode->appendChild($theadNode);
+
+			foreach ($headerRows as $content) {
+				$row = new JatsRow($content);
+				$theadNode->appendChild($row);
+				$row->setContent();
+			}
+		}
+
+		// Create tbody element as required by JATS 1.1 (SPS 1.9)
+		// tbody is always created even if there are no body rows (though that would be unusual)
+		$tbodyNode = $this->ownerDocument->createElement('tbody');
+		$tableNode->appendChild($tbodyNode);
+
+		// Add all body rows inside tbody
+		foreach ($bodyRows as $content) {
 			$row = new JatsRow($content);
-			$tableNode->appendChild($row);
+			$tbodyNode->appendChild($row);
 			$row->setContent();
 		}
 	}

--- a/src/docx2jats/jats/Text.php
+++ b/src/docx2jats/jats/Text.php
@@ -57,6 +57,10 @@ class Text {
 					$domElement->appendChild($nodeElement);
 					if ($type == "ext-link") {
 						$nodeElement->setAttribute("xlink:href", $jatsText->getLink());
+						$extLinkType = LinkTypeHelper::inferType($jatsText->getLink());
+						if ($extLinkType) {
+							$nodeElement->setAttribute("ext-link-type", $extLinkType);
+						}
 					}
 				} else {
 					foreach ($type as $insideKey => $insideType) {
@@ -84,6 +88,10 @@ class Text {
 					$nodeElement->nodeValue = htmlspecialchars($jatsText->getContent());
 					if ($type == "ext-link"){
 						$nodeElement->setAttribute("xlink:href", $jatsText->getLink());
+						$extLinkType = LinkTypeHelper::inferType($jatsText->getLink());
+						if ($extLinkType) {
+							$nodeElement->setAttribute("ext-link-type", $extLinkType);
+						}
 					}
 
 					foreach ($prevElements as $prevKey => $prevElement) {

--- a/src/docx2jats/objectModel/body/Row.php
+++ b/src/docx2jats/objectModel/body/Row.php
@@ -17,6 +17,7 @@ class Row extends DataObject {
 
 	private $properties = array();
 	private $cells = array();
+	private $isHeader = false;
 
 	public function __construct(\DOMElement $domElement, Document $ownerDocument, Table $parent) {
 		parent::__construct($domElement, $ownerDocument, $parent);
@@ -55,5 +56,19 @@ class Row extends DataObject {
 
 	public function getContent() {
 		return $this->cells;
+	}
+
+	/**
+	 * @param bool $isHeader
+	 */
+	public function setIsHeader(bool $isHeader): void {
+		$this->isHeader = $isHeader;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isHeader(): bool {
+		return $this->isHeader;
 	}
 }

--- a/src/docx2jats/objectModel/body/Table.php
+++ b/src/docx2jats/objectModel/body/Table.php
@@ -30,8 +30,14 @@ class Table extends InfoBlock {
 
 		$contentNodes = $this->getXpath()->query($xpathExpression, $this->getDomElement());
 		if ($contentNodes->count() > 0) {
+			$isFirstRow = true;
 			foreach ($contentNodes as $contentNode) {
 				$row = new Row($contentNode, $this->getOwnerDocument(), $this);
+				// Mark first row as header for JATS <thead> generation
+				if ($isFirstRow) {
+					$row->setIsHeader(true);
+					$isFirstRow = false;
+				}
 				$content[] = $row;
 			}
 		}


### PR DESCRIPTION

Este PR introduce mejoras significativas en el conversor `DocxToJats`, divididas en dos grandes ejes: el soporte automatizado para el atributo `ext-link-type` en enlaces externos y la generación semántica completa de tablas conforme a las especificaciones de JATS 

## 🛠️ Cambios Implementados

### 1. Soporte para `ext-link-type` en Enlaces Externos
Se automatizó la detección del tipo de enlace externo para enriquecer las etiquetas `<ext-link>` en el XML de salida, evitando tener que definirlos manualmente.

* **Nueva clase `LinkTypeHelper`:** Se creó un componente encargado exclusivamente de analizar las URL mediante expresiones regulares y patrones de dominio. Puede inferir tipos específicos como `doi`, `ftp`, `pmid`, `pmcid`, `pdb`, `sprot`, entre otros, cayendo en `uri` por defecto.
* **Integración en Referencias (`Reference.php`):** Al procesar los datos bibliográficos (CSL), si existe una URL, se invoca al helper para inyectar dinámicamente el atributo `ext-link-type`.
* **Integración en Bloques de Texto (`Text.php`):** Se actualizó la extracción de texto inline para que los enlaces incrustados en los párrafos también reciban el atributo `ext-link-type` correspondiente.

### 2. Estructuración de Tablas JATS
Se reestructuró la forma en que se procesan y maquetan las tablas provenientes del archivo DOCX para garantizar la validez del esquema JATS.

* **Soporte para `<thead>` y `<tbody>` (`Table.php`):** El generador ahora divide explícitamente las filas de la tabla. Si existen filas marcadas como cabecera, se agrupan dentro de un elemento `<thead>`. El resto de las filas se envuelven obligatoriamente dentro de un elemento `<tbody>`, corrigiendo la estructura plana anterior.
* **Diferenciación de Celdas `<th>` y `<td>` (`Cell.php` y `Row.php`):** El constructor de celdas ahora acepta una bandera condicional. Si la fila es de cabecera, la celda se genera estructuralmente como un elemento `<th>`; de lo contrario, se genera como `<td>`.
* **Identificación Automática de la Primera Fila (`objectModel/body/Table.php`):** Al mapear el modelo de objetos del documento, se fuerza que la primera fila de la tabla sea tratada de manera predeterminada como cabecera (`setIsHeader(true)`), permitiendo que la lógica de conversión dispare la maquetación semántica.
* **Flexibilidad en Elementos Base (`Element.php`):** Se modificó el constructor base para permitir la sobreescritura explícita del nombre del elemento (`$elementNameOverride`), permitiendo el cambio dinámico entre etiquetas hermanas como `th` y `td`.

## 📂 Archivos Modificados

* **`src/docx2jats/jats/LinkTypeHelper.php`** *(Nuevo)*: Lógica de inferencia de tipos de URL.
* **`src/docx2jats/jats/Reference.php`**: Inyección de atributos de enlace en citas/referencias.
* **`src/docx2jats/jats/Text.php`**: Inyección de atributos de enlace en texto libre.
* **`src/docx2jats/jats/Cell.php`**: Lógica de renderizado para `<th>` y `<td>`.
* **`src/docx2jats/jats/Element.php`**: Constructor extendido para soportar nombres dinámicos.
* **`src/docx2jats/jats/Row.php`**: Transmisión del estado de cabecera a las celdas hijas.
* **`src/docx2jats/jats/Table.php`**: Segmentación y creación de nodos `<thead>` y `<tbody>`.
* **`src/docx2jats/objectModel/body/Row.php`**: Propiedad, getters y setters para el estado `isHeader`.
* **`src/docx2jats/objectModel/body/Table.php`**: Marcado automático de la primera fila como cabecera.